### PR TITLE
more data types

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/gocql/gocql v0.0.0-20200624222514-34081eda590e
 	github.com/grafana/grafana-plugin-sdk-go v0.75.0
 	github.com/magefile/mage v1.10.0 // indirect
+	gopkg.in/inf.v0 v0.9.1
 )


### PR DESCRIPTION
This patch adds support for the following CQL types:
timestamp
bigint, int
smallint
boolean
double, varint, decimal
float
tinyint

All other types will be translated to string